### PR TITLE
Adding JSDoc documentation of classes

### DIFF
--- a/js/classes.js
+++ b/js/classes.js
@@ -1,24 +1,62 @@
+/**
+ * @fileOverview Classes.
+ */
+
+
+/**
+ * Identity class.
+ * @param {string} id Identifier for this identity.
+ * @constructor
+ */
 function Identity(id) {
   this.id = this.key = id;
   return this;
-}
+};
 
+
+/**
+ * Contact class.
+ * @param {string} address Contact's address.
+ * @constructor
+ */
 function Contact(address) {
   this.address = this.key = address;
   return this;
-}
+};
 
+
+/**
+ * Address class used by Contact.
+ * @param {string} address An address.
+ * @constructor
+ */
 function Address(address) {
   this.address = this.key = address;
   return this;
-}
+};
 
+
+/**
+ * Transaction class.
+ * @param {string} tx Text.
+ * @constructor
+ */
 function Transaction(tx) {
   this.tx = this.key = tx;
   return this;
 }
 
-Database = function(name, password, callback) {
+
+/**
+ * Database constructor.
+ * @param {string|Array.<string>|Object} name Optional string or array of string
+ *   or object.  Consider renaming to 'keys' to match API.
+ *   @see  http://developer.chrome.com/extensions/storage.html#type-StorageArea
+ * @param {string} password Password.
+ * @param {Function} callback Function executed on load / save.
+ * @constructor
+ */
+Database = function(keys, password, callback) {
   var callback = callback || function(){};
   this.name = name;
   this.password = password;
@@ -33,8 +71,14 @@ Database = function(name, password, callback) {
       self._load(callback);
     }
   });
-}
+};
 
+
+/**
+ * Loads JSON data object into this.data.
+ * @param {Function} callback Function executed on after data loaded.
+ * @private
+ */
 Database.prototype._load = function(callback) {
   var callback = callback || function(){};
   var self = this;
@@ -46,8 +90,14 @@ Database.prototype._load = function(callback) {
       callback(true);
     }
   });
-}
+};
 
+
+/**
+ * Saves JSON data object into local database.
+ * @param {Function} callback Function executed on after data saved.
+ * @private
+ */
 Database.prototype._save = function(callback) {
   var callback = callback || function(){};
   try {
@@ -60,8 +110,15 @@ Database.prototype._save = function(callback) {
   } catch(e) {
     callback(true);
   }
-}
+};
 
+
+/**
+ * Adds a new field to the database.
+ * @param {string} key Key for the new field.  Must be unique.
+ * @param {Object} obj Data object to be saved.
+ * @param {Function} callback Function executed on after data saved.
+ */
 Database.prototype.create = function(key, obj, callback) {
   var self = this;
   var callback = callback || function(){};
@@ -72,8 +129,14 @@ Database.prototype.create = function(key, obj, callback) {
     self.data[key] = obj;
     self._save(callback);
   });
-}
+};
 
+
+/**
+ * Reads in the data object for specified key.
+ * @param {string?} key Key for the field or null.
+ * @param {Function} callback Function called with the requested data.
+ */
 Database.prototype.read = function(key, callback) {
   var self = this;
   var callback = callback || function(){};
@@ -84,8 +147,15 @@ Database.prototype.read = function(key, callback) {
       callback(self.data[key]);
     }
   });
-}
+};
 
+
+/**
+ * Updates an existing field.
+ * @param {string?} key Key for the field or null.
+ * @param {Object} obj Data object to be written to database.
+ * @param {Function} callback Function called after database is updated.
+ */
 Database.prototype.update = function(key, obj, callback) {
   var self = this;
   var callback = callback || function(){};
@@ -96,8 +166,14 @@ Database.prototype.update = function(key, obj, callback) {
     self.data[key] = obj;
     self._save(callback);
   });
-}
+};
 
+
+/**
+ * Removes an item from database.
+ * @param {string} key Key for the field.
+ * @param {Function} callback Function called after data is removed.
+ */
 Database.prototype.remove = function(key, callback) {
   var self = this;
   var callback = callback || function(){};
@@ -105,5 +181,4 @@ Database.prototype.remove = function(key, callback) {
     delete self.data[key];
     self._save(callback);
   });
-}
-
+};


### PR DESCRIPTION
Example [JSDoc](https://github.com/jsdoc3/jsdoc) comments and type annotation.

Are darkwallet devs interested in adopting this convention so that documentation can be generated?
