### PR TITLE
generate new temporary identity

### DIFF
--- a/html/partials/lobby.html
+++ b/html/partials/lobby.html
@@ -48,7 +48,7 @@
           </div>
           <h5>Your permanent identity</h5>
           <div class="wrapper"><identicon title="{{myself.pubKeyHex}}" hash="myself.pubKeyHex" icon-size="32"></identicon> {{myself.name}}</div>
-          <h5>Your temporary identity</h5>
+          <h5>Your temporary identity</h5><button ng-click="newTempIdentity()">New</button>
           <div class="wrapper"><identicon title="{{comms.pubKeyHex}}" hash="comms.pubKeyHex" icon-size="32"></identicon> {{comms.name}}</div>
           <h5>Peers</h5>
           <div ng-repeat="peer in peers">

--- a/js/backend/channels/transport.js
+++ b/js/backend/channels/transport.js
@@ -11,18 +11,14 @@ function (Bitcoin, Mnemonic, Services) {
   function Transport(identity, obeliskClient) {
     this.client = obeliskClient;
     this.channels = {};
+    this.sessionKey = {};
 
     this.requests = [];
     this.peers = [];
     this.peerIds = [];
     this.subscribed = false;
 
-    // Session key
-    if (!identity.sessionKey) {
-        identity.sessionKey = new Bitcoin.Key();
-        identity.sessionKey.compressed = true;
-    }
-    var sessionKey = identity.sessionKey;
+    this.newSession();
 
     // Identity (communications) key
     var selfKey;
@@ -36,11 +32,19 @@ function (Bitcoin, Mnemonic, Services) {
         identity.store.save();
     }
     this.getSelfKey = function() { return selfKey; }
-    this.getSessionKey = function() { return sessionKey; }
+    this.getSessionKey = function() { return this.sessionKey; }
 
     // Initialize some own data
-    this.comms = this.initializePeer(sessionKey.getPub().toBytes(true));
+    this.comms = this.initializePeer(this.sessionKey.getPub().toBytes(true));
     this.myself = this.initializePeer(selfKey.getPub().toBytes(true));
+  }
+
+  /*
+   * Initialize a new discardable session key
+   */
+  Transport.prototype.newSession = function() {
+    this.sessionKey = new Bitcoin.Key();
+    this.sessionKey.compressed = true;
   }
 
   Transport.prototype.getClient = function() {

--- a/js/frontend/controllers/lobby.js
+++ b/js/frontend/controllers/lobby.js
@@ -125,6 +125,11 @@ function (controllers, DarkWallet, Services, ChannelLink, Bitcoin, Protocol) {
         }
     }
 
+    $scope.newTempIdentity = function() {
+      currentChannel.newSession();
+      currentChannel.sendOpening();
+    }
+
     // Action to start announcements and reception
     $scope.joinChannel = function() {
         connectChannel($scope.pairCode);


### PR DESCRIPTION
These commits add a button to generate a new temporary identity for lobby. The work is incomplete and requires correction by someone better versed in Darkwallet's internals.

The most important matter to fix is management of transports. Request for a new tmp ID is sent to a single channel, which is fine when only one channel is used, but in case of more channels, the identities for each channel begin to differ. There are two directions this can be taken:
- allow different IDs for different channels
- keep one ID for all channels

The way I left it, clicking the "New" button changes the keys for the currently active channel, giving a new apparent ID for it. Identities in remaining channels are preserved, However, somehow the hash of the new ID is set for all channels. Thus the identicon on the right always shows the last generated ID.

The second matter to fix is appearance of the ugly "New" button.
