### PR TITLE
Fixes long addresses in wallet columns

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -5033,7 +5033,10 @@ form.send {
 
 .seed {
   background: url(../images/seed.svg) center/cover no-repeat; }
-
+  
+.wordwrap{
+word-wrap:break-word;
+}
 /* Scrollbars ---------------------  */
 ::-webkit-scrollbar {
   width: 8px; }
@@ -5044,3 +5047,4 @@ form.send {
 ::-webkit-scrollbar-thumb {
   border-radius: 3px;
   background: #27ae60; }
+

--- a/html/wallet/dashboard.html
+++ b/html/wallet/dashboard.html
@@ -41,7 +41,7 @@
              {{row.total | amountFilter}}
              </div>
              <div class="small-6 columns">
-               <div ng-hide="row.contact">
+               <div ng-hide="row.contact" class="wordwrap">
                 {{row.address}}
                 <span class="label radius" ng-show="row.isStealth"><div class="fa fa-fighter-jet"></div> stealth</span>
                </div>

--- a/html/wallet/history.html
+++ b/html/wallet/history.html
@@ -35,7 +35,7 @@
              {{(row.total) | amountFilter}}
              </div>
              <div class="small-5 columns">
-               <div ng-hide="row.contact">
+               <div ng-hide="row.contact" class="wordwrap">
                 {{row.address}}
                 <span class="label radius" ng-show="row.isStealth"><div class="fa fa-fighter-jet"></div> stealth</span>
                </div>


### PR DESCRIPTION
The wallet columns don't properly display a long stealth address, by adding a wordwrap class to the address column, the address gets wrapped around and displays nicely with the stealth icon.
