### PR TITLE
Chat lobby: break-all instead of break-word

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -5064,7 +5064,7 @@ div.pockets {
 
 
 div.chat-text {
-  word-wrap: break-word; }
+  word-break: break-all; }
 
 /* ----------- Backgrounds ---------------- */
 .setback.net {

--- a/sass/app.scss
+++ b/sass/app.scss
@@ -365,7 +365,7 @@ div.wallet-view {  }
 
 
 div.chat-text {
-	word-wrap: break-word;
+	word-break: break-all;
 }
 
 /* ----------- Backgrounds ---------------- */


### PR DESCRIPTION
Stealth addresses are long, break-all > break-word.
