### PR TITLE
Currency format improvements

### DIFF
--- a/js/dwutil/currencyformat.js
+++ b/js/dwutil/currencyformat.js
@@ -112,7 +112,10 @@ CurrencyFormatting.formatBtc = function(satoshis, unit) {
     }
     if (!unit) unit = DarkWallet.getIdentity().settings.currency;
 
-    return this.asBtc(satoshis, unit).toLocaleString() + " " + symbol[unit];
+	var btc_price = this.asBtc(satoshis, unit),
+	parts = btc_price.toString().split(".");
+    parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+	return parts.join(".") + " " + symbol[unit];
 }
 
 /**

--- a/js/dwutil/currencyformat.js
+++ b/js/dwutil/currencyformat.js
@@ -10,7 +10,7 @@ function CurrencyFormatting() {
 var symbol = {
   'BTC': '฿',
   'mBTC': 'm฿',
-  'bits': 'µ'
+  'bits': 'bits'
 }
 
 /**
@@ -112,7 +112,7 @@ CurrencyFormatting.formatBtc = function(satoshis, unit) {
     }
     if (!unit) unit = DarkWallet.getIdentity().settings.currency;
 
-    return this.asBtc(satoshis, unit) + " " + symbol[unit];
+    return this.asBtc(satoshis, unit).toLocaleString() + " " + symbol[unit];
 }
 
 /**
@@ -123,8 +123,12 @@ CurrencyFormatting.formatFiat = function(satoshis, fiatCurrency) {
 
     var converted = this.asFiat(satoshis, fiatCurrency);
     if (!(converted === undefined)) {
-        var currency = FiatCurrencies[fiatCurrency];
-        return converted+" "+currency.symbol_native;
+        converted = parseFloat(converted).toLocaleString(undefined, {
+    		style: 'currency',
+    		currency: fiatCurrency,
+    		minimumFractionDigits: 2
+    	});
+        return converted;
     }
 }
 


### PR DESCRIPTION
What has changed:
- "1,000 bits" instead of "1000 µ" (adds commas with .toLocaleString())
- Fiat now displays as "$600.00" - originally "600.00 $".

Fiat money displays using toLocaleString, this takes into consideration multiple languages when the locale changes ("hi-IN", "en-US", etc) - if the language is set as Russian, the currency code will be "руб", if the browser is in English, it will show "RUB" instead. If the browser is in Hindi, the numbers change to the Hindi numerical system, etc.
