### PR TITLE
fix undoTransaction

### DIFF
--- a/js/frontend/controllers/send.js
+++ b/js/frontend/controllers/send.js
@@ -285,6 +285,7 @@ function (controllers, Port, DarkWallet, BtcUtils, CurrencyFormat, Bitcoin) {
               // Since it didn't go out at all, let's undo the transaction.
               if (!radarCache.radar) {
                   DarkWallet.getIdentity().wallet.undoTransaction(metadata.tx);
+                  DarkWallet.service.badge.setItems();
               }
           } else {
               timeoutId = $timeout(function(){onSendTimeout()}, 10000);

--- a/js/model/wallet.js
+++ b/js/model/wallet.js
@@ -783,7 +783,7 @@ Wallet.prototype.undoTransaction = function(tx) {
         if (output && output.spend) {
             if (!output.spendpending) {
                 var walletAddress = self.getWalletAddress(output.address);
-                walletAddress += output.value;
+                walletAddress.balance += output.value;
             }
             delete output.spend;
             delete output.spendheight;

--- a/js/model/wallet.js
+++ b/js/model/wallet.js
@@ -801,6 +801,12 @@ Wallet.prototype.undoTransaction = function(tx) {
             }
         }
     });
+
+    // also remove the transaction from tasks
+    var task = self.identity.tasks.search('send', 'hash', txHash);
+    if (task) {
+        self.identity.tasks.removeTask('send', task);
+    }
 };
 
 


### PR DESCRIPTION
simple bug in undoTransaction ("walletAddress +=" where it should be "walletAddress.balance +=")

Also even though undoTransaction makes the unconfirmed amount go away and the wallet page go pack to normal the non-broadcasting transaction still stays around forever in the popup so I had it remove the task

I'm just getting started with the darkwallet code so feel free to change it if made the fix in the wrong place/coding style/whatever
