### PR TITLE
don't allow transactions with negative amounts or negative fee

### DIFF
--- a/html/partials/send.html
+++ b/html/partials/send.html
@@ -68,7 +68,7 @@
             <div class="small-4 columns">
               <a class="button radius prefix fa fa-plus" ng-click="enableAutoAddFields()"> Add another recipient</a>
               <h6>Fee</h6>
-              <input ng-model="forms.send.fee" type="text" class="radius" />
+              <input ng-model="forms.send.fee" type="text" ng-change="validateSendForm()" class="radius" />
             </div>
             <div class="small-8 columns">
               <a ng-click="toggleCoinJoin()" ng-class="{'fa-square-o':!forms.send.mixing, 'fa-check-square-o': forms.send.mixing}" class="fa button postfix radius">{{forms.send.mixing?'CoinJoin mixing enabled':'CoinJoin mixing disabled'}}</a>

--- a/js/frontend/controllers/send.js
+++ b/js/frontend/controllers/send.js
@@ -159,7 +159,8 @@ function (controllers, Port, DarkWallet, BtcUtils, CurrencyFormat, Bitcoin) {
           }
       }
       var spend = prepareRecipients();
-      if ((spend.recipients.length > 0) && (spend.amount > dustThreshold)) {
+      var checkNegative = spend.recipients.filter(function(r) { return r.amount < 0; });
+      if ((spend.recipients.length > 0) && (spend.amount > dustThreshold) && (!checkNegative.length) && (sendForm.fee >= 0)) {
           $scope.sendEnabled = true;
       } else {
           $scope.sendEnabled = false;

--- a/js/model/tx.js
+++ b/js/model/tx.js
@@ -35,7 +35,13 @@ function Transaction(store, identity) {
 Transaction.prototype.prepare = function(pocketId, recipients, changeAddress, fee, reserveOutputs) {
     var wallet = this.identity.wallet;
     var totalAmount = 0;
+    if (fee < 0) {
+        throw new Error('negative fee');
+    }
     recipients.forEach(function(recipient) {
+        if (recipient.amount < 0) {
+            throw new Error ('negative amount');
+        }
         totalAmount += recipient.amount;
     });
     var isStealth = false;


### PR DESCRIPTION
A sane user won't be trying to send negative transactions, but the wallet shouldn't let them anyway. Also transactions with negative amounts mess up the wallet balance.
I think what happens with the wallet balance is the utxo used in the transaction is seen as spent and subtracted from the unconfirmed amount, but it never sees the change coming back from the invalid negative transaction, so that's not added to the unconfirmed and the wallet balance is too low. Then when it finally times out and calls undo that messes up the balance more. But I don't think that needs separate fixing because as long as darkwallet isn't trying to send invalid transactions it shouldn't be a problem?
