### PR TITLE
Feature: export keys

### DIFF
--- a/html/partials/tools.html
+++ b/html/partials/tools.html
@@ -9,6 +9,9 @@
               <div ng-include="'tools/signing.html'"></div>
               <div ng-include="'tools/verifying.html'"></div>
           </div>
+          <div ng-controller="ExportingCtrl">
+              <div ng-include="'tools/exporting.html'"></div>
+          </div>
           <h4>Browsing</h4>
           <a class="button fa fa-sitemap postfix" href="#browser">Browser</a>
           <h4>Developer mode</h4>

--- a/html/tools/exporting.html
+++ b/html/tools/exporting.html
@@ -1,8 +1,7 @@
 <h3 ng-show="!tools.open || tools.exportOpen">Key management</h3>
-<a class="button fa fa-pencil postfix" ng-click="tools.open=true;tools.exportOpen=true" ng-show="!tools.open" novalidate>Export keys</a>
+<a class="button fa fa-upload postfix" ng-click="tools.open=true;tools.exportOpen=true" ng-show="!tools.open" novalidate>Export keys</a>
 <form name="exportingForm" ng-show="tools.exportOpen" ng-submit="exportKeys()">
-    <label>Addresses (leave empty for all):</label>
-    <textarea ng-model="tools.exportKeys" rows="4" cols="50"></textarea>
+    <label>All keys will be exported (this might take a while).</label>
     <div class="row collapse">
       <div class="medium-6 columns">
         <button type="submit" class="button fa fa-pencil postfix">Export</button>

--- a/html/tools/exporting.html
+++ b/html/tools/exporting.html
@@ -1,0 +1,14 @@
+<h3 ng-show="!tools.open || tools.exportOpen">Exporting</h3>
+<a class="button fa fa-pencil postfix" ng-click="tools.open=true;tools.exportOpen=true" ng-show="!tools.open" novalidate>Export keys</a>
+<form name="exportingForm" ng-show="tools.exportOpen" ng-submit="exportKeys()">
+    <label>Public keys (leave empty for all):</label>
+    <textarea ng-model="tools.exportKeys" rows="4" cols="50"></textarea>
+    <div class="row collapse">
+      <div class="medium-6 columns">
+        <button type="submit" class="button fa fa-pencil postfix">Export</button>
+      </div>
+      <div class="medium-6 columns">
+        <a class="button alert fa fa-times postfix" ng-click="tools.exportOpen=false;tools.open=false;">Cancel</a>
+      </div>
+    </div>
+</form>

--- a/html/tools/exporting.html
+++ b/html/tools/exporting.html
@@ -1,7 +1,7 @@
-<h3 ng-show="!tools.open || tools.exportOpen">Exporting</h3>
+<h3 ng-show="!tools.open || tools.exportOpen">Key management</h3>
 <a class="button fa fa-pencil postfix" ng-click="tools.open=true;tools.exportOpen=true" ng-show="!tools.open" novalidate>Export keys</a>
 <form name="exportingForm" ng-show="tools.exportOpen" ng-submit="exportKeys()">
-    <label>Public keys (leave empty for all):</label>
+    <label>Addresses (leave empty for all):</label>
     <textarea ng-model="tools.exportKeys" rows="4" cols="50"></textarea>
     <div class="row collapse">
       <div class="medium-6 columns">

--- a/js/frontend/controllers/exporting.js
+++ b/js/frontend/controllers/exporting.js
@@ -1,0 +1,41 @@
+'use strict';
+
+// TODO: remove stealth?
+define(['./module', 'darkwallet', 'bitcoinjs-lib', 'util/stealth'], function (controllers, DarkWallet, Bitcoin, Stealth) {
+
+  // Controller
+  controllers.controller('ExportingCtrl', ['$scope', 'notify', 'modals', function($scope, notify, modals) {
+
+  // Get text from textbox, return list of addresses to export
+  var parseAddressList = function(addressList) {
+    // TODO
+  }
+
+  $scope.exportKeys = function() {
+      var identity = DarkWallet.getIdentity();
+      var allAddresses = identity.wallet.getPocketAddresses('all');
+
+      modals.password('Unlock password', function(password) {
+          try {
+	      var output = '';
+              for (var i = 0; i < allAddresses.length; i++) {
+                  var address = allAddresses[i];
+                  var walletAddress = identity.wallet.getWalletAddress(address);
+                  identity.wallet.getPrivateKey(walletAddress.index, password, function(privKey) {
+                      output += address + ',' + privKey + '\n';
+                  } );
+              }
+              $scope.tools.output = output;
+              $scope.tools.status = 'ok';
+              $scope.tools.exportOpen = false;
+              $scope.tools.open = false;
+              notify.success("Exported");
+          } catch (e) {
+              notify.error('Incorrect password', e.message);
+          }
+      } );
+  }
+
+
+}]);
+});

--- a/js/frontend/controllers/exporting.js
+++ b/js/frontend/controllers/exporting.js
@@ -1,7 +1,6 @@
 'use strict';
 
-// TODO: remove stealth?
-define(['./module', 'darkwallet', 'bitcoinjs-lib', 'util/stealth'], function (controllers, DarkWallet, Bitcoin, Stealth) {
+define(['./module', 'darkwallet'], function (controllers, DarkWallet) {
 
   // Controller
   controllers.controller('ExportingCtrl', ['$scope', 'notify', 'modals', function($scope, notify, modals) {

--- a/js/frontend/controllers/exporting.js
+++ b/js/frontend/controllers/exporting.js
@@ -6,11 +6,6 @@ define(['./module', 'darkwallet', 'bitcoinjs-lib', 'util/stealth'], function (co
   // Controller
   controllers.controller('ExportingCtrl', ['$scope', 'notify', 'modals', function($scope, notify, modals) {
 
-  // Get text from textbox, return list of addresses to export
-  var parseAddressList = function(addressList) {
-    // TODO
-  }
-
   $scope.exportKeys = function() {
       var identity = DarkWallet.getIdentity();
       var allAddresses = identity.wallet.getPocketAddresses('all');

--- a/js/frontend/controllers/index.js
+++ b/js/frontend/controllers/index.js
@@ -35,5 +35,6 @@ define([
     './fund',
     './tools',
     './signing',
+    './exporting',
     './rcv_stealth'
 ], function () {});

--- a/test/unit/frontend/controllers/exportingSpec.js
+++ b/test/unit/frontend/controllers/exportingSpec.js
@@ -1,0 +1,4 @@
+'use strict';
+
+define(['frontend/controllers/exporting'], function (Exporting) {
+});


### PR DESCRIPTION
"Tools" page, on the left.

**Should not be pulled without review!** Possible issues:
- exported to window, not file (accesible via DOM?..);
- exported in `<address>,<secret exponent>` format - might be hard to import;
- stealth keys not exported;
- iterating over addresses to get keys is (probably) sub-optimal;
- unit test is empty.

Making PR only since this seems to be a much-wanted feature in light of #164.
