### PR TITLE
Possible fix to #218: text overflow in "All pockets" screen.

### DIFF
--- a/src/css/app.css
+++ b/src/css/app.css
@@ -3806,6 +3806,7 @@ meta.foundation-mq-topbar {
   top: 0;
   bottom: 0;
   position: absolute;
+  overflow-x: hidden;
   overflow-y: auto;
   background: #333;
   z-index: 1001;
@@ -5149,7 +5150,8 @@ textarea.script {
 
 .pocket-square {
   min-height: 120px;
-  margin-bottom: -0.3rem; }
+  margin-bottom: -0.3rem;
+  overflow-x: hidden; }
 
 .contact-mosaic .panel:hover, div.notifications .panel:hover, .pocket-square:hover {
   background: rgba(30, 190, 90, 0.9);

--- a/src/html/wallet/dashboard.html
+++ b/src/html/wallet/dashboard.html
@@ -33,7 +33,7 @@
 
 	    <ul class="large-block-grid-4 medium-block-grid-2 small-block-grid-1">
 			<li ng-repeat="pocket in allPockets" ng-click="selectGridPocket(pocket)">
-				<div class="panel radius pocket-square">
+				<div class="panel radius pocket-square ellipsis">
 	           		<h5>{{pocket.name | pocket}} <small ng-show="pocket.type=='fund'">{{'{0} of {1}'|_:pocket.fund.m:pocket.fund.pubKeys.length}}</small></h5>
         
 	           		<span ng-show="pocket.balance.confirmed">{{pocket.balance.confirmed | formatBtc}} <br><span class="fiat">{{pocket.balance.confirmed | formatFiat}}</span></span>


### PR DESCRIPTION
This also addresses the appearance of a horisontal scrollbar in the left menu (pocket list).
