### PR TITLE
Export keys tool: use its own textarea for output.

### DIFF
--- a/src/css/app.css
+++ b/src/css/app.css
@@ -2121,10 +2121,10 @@ input[type="text"], input[type="password"], input[type="date"], input[type="date
     border-color: #565656;
     outline: none; }
   input[type="text"]:disabled, input[type="password"]:disabled, input[type="date"]:disabled, input[type="datetime"]:disabled, input[type="datetime-local"]:disabled, input[type="month"]:disabled, input[type="week"]:disabled, input[type="email"]:disabled, input[type="number"]:disabled, input[type="search"]:disabled, input[type="tel"]:disabled, input[type="time"]:disabled, input[type="url"]:disabled, textarea:disabled {
-    background-color: #888;
+    background-color: #000;
     cursor: default; }
   input[type="text"][disabled], input[type="text"][readonly], fieldset[disabled] input[type="text"], input[type="password"][disabled], input[type="password"][readonly], fieldset[disabled] input[type="password"], input[type="date"][disabled], input[type="date"][readonly], fieldset[disabled] input[type="date"], input[type="datetime"][disabled], input[type="datetime"][readonly], fieldset[disabled] input[type="datetime"], input[type="datetime-local"][disabled], input[type="datetime-local"][readonly], fieldset[disabled] input[type="datetime-local"], input[type="month"][disabled], input[type="month"][readonly], fieldset[disabled] input[type="month"], input[type="week"][disabled], input[type="week"][readonly], fieldset[disabled] input[type="week"], input[type="email"][disabled], input[type="email"][readonly], fieldset[disabled] input[type="email"], input[type="number"][disabled], input[type="number"][readonly], fieldset[disabled] input[type="number"], input[type="search"][disabled], input[type="search"][readonly], fieldset[disabled] input[type="search"], input[type="tel"][disabled], input[type="tel"][readonly], fieldset[disabled] input[type="tel"], input[type="time"][disabled], input[type="time"][readonly], fieldset[disabled] input[type="time"], input[type="url"][disabled], input[type="url"][readonly], fieldset[disabled] input[type="url"], textarea[disabled], textarea[readonly], fieldset[disabled] textarea {
-    background-color: #888;
+    background-color: #000;
     cursor: default; }
   input[type="text"].radius, input[type="password"].radius, input[type="date"].radius, input[type="datetime"].radius, input[type="datetime-local"].radius, input[type="month"].radius, input[type="week"].radius, input[type="email"].radius, input[type="number"].radius, input[type="search"].radius, input[type="tel"].radius, input[type="time"].radius, input[type="url"].radius, textarea.radius {
     border-radius: 3px; }
@@ -2158,7 +2158,7 @@ select {
     background-color: #3a3a3a;
     border-color: #565656; }
   select:disabled {
-    background-color: #888;
+    background-color: #000;
     cursor: default; }
 
 /* Adjust margin for form elements below */

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -3856,7 +3856,7 @@ ul.off-canvas-list {
     font-size: 0.75rem;
     font-weight: bold;
     background: #333;
-    border-top: 1px solid #505050;
+    border-top: none;
     border-bottom: none;
     margin: 0; }
   ul.off-canvas-list li a {

--- a/src/html/partials/new_wallet.html
+++ b/src/html/partials/new_wallet.html
@@ -35,7 +35,7 @@
       <form ng-submit="passwordSubmit()">
           <div class="row topmargin">
             <div class="small-6 columns">
-              <input type="text" ng-model="form.name" placeholder="{{'Name for this wallet'|_}}" autofocus ng-required="true" />
+              <input type="text" ng-model="form.name" maxlength="12" placeholder="{{'Name for this wallet'|_}}" autofocus ng-required="true" />
             </div>
             <div class="small-6 columns">
               <select id="select-language" ng-model="form.language" ng-change="changeLanguage()" ng-options="language.code as language.name for language in languages"></select>
@@ -79,5 +79,5 @@
             </div>
       </form>
     </div>
-  </div> 
+  </div>
 </div>

--- a/src/html/tools/exporting.html
+++ b/src/html/tools/exporting.html
@@ -1,19 +1,18 @@
 <h3 ng-show="!tools.open || tools.exportOpen">{{'Key management'|_}}</h3>
 <a class="button fa fa-upload postfix ng-animate-disabled" ng-click="tools.open=true;tools.exportOpen=true" ng-show="!tools.open" novalidate>{{'Export private keys'|_}}</a>
 <form name="exportingForm" ng-show="tools.exportOpen" ng-submit="exportKeys()">
-    <label ng-show="!tools.exportAddresses">{{'All private keys will be exported by default (this might take a while).'|_}}</label>
+    <label ng-show="!tools.exportAddresses">{{'All private keys will be exported (this might take a while).'|_}}</label>
     <div class="row collapse">
       <div class="medium-12 columns">
-        <label>{{'Addresses'|_}}:</label>
         <textarea ng-model="tools.exportAddresses" rows="4" cols="50" placeholder="{{'Addresses to export, one per line...'|_}}"></textarea>
       </div>
     </div>
     <div class="row collapse">
       <div class="medium-6 columns">
-        <button type="submit" class="button fa fa-pencil postfix">{{'Export'|_}}</button>
+        <button type="submit" ng-disabled="tools.exportComplete" class="button fa fa-upload postfix">{{'Export'|_}}</button>
       </div>
       <div class="medium-6 columns">
-        <a class="button alert fa fa-times postfix" ng-click="tools.exportAddresses='';tools.exportOpen=false;tools.open=false;">{{'Close'|_}}</a>
+        <a class="button alert fa fa-times postfix" ng-click="exportKeysClose()">{{'Close'|_}}</a>
       </div>
     </div>
 </form>

--- a/src/html/tools/exporting.html
+++ b/src/html/tools/exporting.html
@@ -1,12 +1,11 @@
 <h3 ng-show="!tools.open || tools.exportOpen">{{'Key management'|_}}</h3>
 <a class="button fa fa-upload postfix ng-animate-disabled" ng-click="tools.open=true;tools.exportOpen=true" ng-show="!tools.open" novalidate>{{'Export private keys'|_}}</a>
 <form name="exportingForm" ng-show="tools.exportOpen" ng-submit="exportKeys()">
-    <label ng-show="!tools.exportAddress">{{'All private keys will be exported (this might take a while).'|_}}</label>
-    <p ng-show="!tools.exportAddress">{{'Write an address to export just one.'|_}}</p>
+    <label ng-show="!tools.exportAddresses">{{'All private keys will be exported by default (this might take a while).'|_}}</label>
     <div class="row collapse">
       <div class="medium-12 columns">
-         <label>{{'Address'|_}}:</label>
-         <input type="text" ng-model="tools.exportAddress" placeholder="{{'Address to export...'|_}}"></input>
+        <label>{{'Addresses'|_}}:</label>
+        <textarea ng-model="tools.exportAddresses" rows="4" cols="50" placeholder="{{'Addresses to export, one per line...'|_}}"></textarea>
       </div>
     </div>
     <div class="row collapse">
@@ -14,7 +13,7 @@
         <button type="submit" class="button fa fa-pencil postfix">{{'Export'|_}}</button>
       </div>
       <div class="medium-6 columns">
-        <a class="button alert fa fa-times postfix" ng-click="tools.exportOpen=false;tools.open=false;">{{'Cancel'|_}}</a>
+        <a class="button alert fa fa-times postfix" ng-click="tools.exportAddresses='';tools.exportOpen=false;tools.open=false;">{{'Close'|_}}</a>
       </div>
     </div>
 </form>

--- a/src/html/wallet/new_pocket.html
+++ b/src/html/wallet/new_pocket.html
@@ -8,10 +8,10 @@
 				</div>
 			</div>
 			<div class="row">
-				<div class="small-6 columns">
-                                          <input type="text" auto-focus ng-model="newPocket.name" placeholder="{{'Name your pocket...'|_}}" />
+				<div class="small-9 columns">
+                                          <input type="text" maxlength="30" auto-focus ng-model="newPocket.name" placeholder="{{'Name your pocket...'|_}}" />
 				</div>
-				
+
 				<div class="small-3 columns">
                                           <input type="submit" class="button small expand radius" value="{{'Create'|_}}" ng-click="createPocket()"/>
 				</div>
@@ -20,7 +20,7 @@
 				</div>-->
 			</div>
                        </form>
-		
+
 		</div>
 
 	</div>

--- a/src/html/wallet/new_pocket.html
+++ b/src/html/wallet/new_pocket.html
@@ -7,13 +7,13 @@
 					<h6>{{'Pockets allow organizing your wallet in different privacy zones'|_}}</h6>
 				</div>
 			</div>
-			<div class="row">
+			<div class="row collapse">
 				<div class="small-9 columns">
                                           <input type="text" maxlength="30" auto-focus ng-model="newPocket.name" placeholder="{{'Name your pocket...'|_}}" />
 				</div>
 
 				<div class="small-3 columns">
-                                          <input type="submit" class="button small expand radius" value="{{'Create'|_}}" ng-click="createPocket()"/>
+                                          <input type="submit" class="button postfix radius" value="{{'Create'|_}}" ng-click="createPocket()"/>
 				</div>
 				<!--<div class="small-3 columns">
                                           <input type="submit" class="button small alert expand radius" value="{{'Cancel'|_}}" ng-click="selectPocket()"/>

--- a/src/html/wallet/new_pocket.html
+++ b/src/html/wallet/new_pocket.html
@@ -9,7 +9,7 @@
 			</div>
 			<div class="row collapse">
 				<div class="small-9 columns">
-                                          <input type="text" maxlength="30" auto-focus ng-model="newPocket.name" placeholder="{{'Name your pocket...'|_}}" />
+                                          <input type="text" maxlength="25" auto-focus ng-model="newPocket.name" placeholder="{{'Name your pocket...'|_}}" />
 				</div>
 
 				<div class="small-3 columns">

--- a/src/js/frontend/controllers/exporting.js
+++ b/src/js/frontend/controllers/exporting.js
@@ -9,6 +9,7 @@ define(['./module', 'darkwallet', 'bitcoinjs-lib'], function (controllers, DarkW
       var identity = DarkWallet.getIdentity();
       var allAddresses;
       var userProvidedInput;
+      $scope.tools.exportComplete = false;
       if ($scope.tools.exportAddresses) {
           allAddresses = $scope.tools.exportAddresses.split('\n');
 	  userProvidedInput = true;
@@ -34,6 +35,7 @@ define(['./module', 'darkwallet', 'bitcoinjs-lib'], function (controllers, DarkW
               }
 
               $scope.tools.exportAddresses = output;
+	      $scope.tools.exportComplete = true;
               $scope.tools.status = 'ok';
 
               notify.success(_('Exported'));
@@ -41,6 +43,13 @@ define(['./module', 'darkwallet', 'bitcoinjs-lib'], function (controllers, DarkW
               notify.error(_('Incorrect password'), _(e.message));
           }
       } );
+  }
+
+  $scope.exportKeysClose = function() {
+      $scope.tools.exportAddresses='';
+      $scope.tools.exportComplete = false;
+      $scope.tools.exportOpen=false;
+      $scope.tools.open=false;
   }
 
 

--- a/src/js/frontend/controllers/exporting.js
+++ b/src/js/frontend/controllers/exporting.js
@@ -8,10 +8,13 @@ define(['./module', 'darkwallet', 'bitcoinjs-lib'], function (controllers, DarkW
   $scope.exportKeys = function() {
       var identity = DarkWallet.getIdentity();
       var allAddresses;
+      var userProvidedInput;
       if ($scope.tools.exportAddresses) {
           allAddresses = $scope.tools.exportAddresses.split('\n');
+	  userProvidedInput = true;
       } else {
           allAddresses = identity.wallet.getPocketAddresses('all');
+	  userProvidedInput = false;
       }
 
       modals.password(_('Write your password'), function(password) {
@@ -25,8 +28,8 @@ define(['./module', 'darkwallet', 'bitcoinjs-lib'], function (controllers, DarkW
                       identity.wallet.getPrivateKey(walletAddress, password, function(privKey) {
                           output += address + ',' + privKey.toWIF(Bitcoin.networks[identity.wallet.network]) + '\n';
                       } );
-                  } else if (allAddresses.length == 1) {
-                      notify.error(_('Address not from this wallet'));
+                  } else if (userProvidedInput) {
+                      notify.error(_('Address not from this wallet'), _(address));
                   }
               }
 

--- a/src/js/frontend/controllers/exporting.js
+++ b/src/js/frontend/controllers/exporting.js
@@ -22,6 +22,7 @@ define(['./module', 'darkwallet', 'bitcoinjs-lib'], function (controllers, DarkW
           try {
               var output = '';
               for (var i = 0; i < allAddresses.length; i++) {
+		  // Fill wallet address structure with index, type, etc.
                   var address = allAddresses[i];
                   var walletAddress = identity.wallet.getWalletAddress(address);
                   // Make sure we only export normal and stealth keys

--- a/src/js/frontend/controllers/exporting.js
+++ b/src/js/frontend/controllers/exporting.js
@@ -7,9 +7,9 @@ define(['./module', 'darkwallet', 'bitcoinjs-lib'], function (controllers, DarkW
 
   $scope.exportKeys = function() {
       var identity = DarkWallet.getIdentity();
-      var allAddresses
-      if ($scope.tools.exportAddress) {
-          allAddresses = [$scope.tools.exportAddress];
+      var allAddresses;
+      if ($scope.tools.exportAddresses) {
+          allAddresses = $scope.tools.exportAddresses.split('\n');
       } else {
           allAddresses = identity.wallet.getPocketAddresses('all');
       }
@@ -27,13 +27,12 @@ define(['./module', 'darkwallet', 'bitcoinjs-lib'], function (controllers, DarkW
                       } );
                   } else if (allAddresses.length == 1) {
                       notify.error(_('Address not from this wallet'));
-                      return;
                   }
               }
-              $scope.tools.output = output;
+
+              $scope.tools.exportAddresses = output;
               $scope.tools.status = 'ok';
-              $scope.tools.exportOpen = false;
-              $scope.tools.open = false;
+
               notify.success(_('Exported'));
           } catch (e) {
               notify.error(_('Incorrect password'), _(e.message));

--- a/src/js/frontend/controllers/exporting.js
+++ b/src/js/frontend/controllers/exporting.js
@@ -12,15 +12,15 @@ define(['./module', 'darkwallet', 'bitcoinjs-lib'], function (controllers, DarkW
       $scope.tools.exportComplete = false;
       if ($scope.tools.exportAddresses) {
           allAddresses = $scope.tools.exportAddresses.split('\n');
-	  userProvidedInput = true;
+          userProvidedInput = true;
       } else {
           allAddresses = identity.wallet.getPocketAddresses('all');
-	  userProvidedInput = false;
+          userProvidedInput = false;
       }
 
       modals.password(_('Write your password'), function(password) {
           try {
-	      var output = '';
+              var output = '';
               for (var i = 0; i < allAddresses.length; i++) {
                   var address = allAddresses[i];
                   var walletAddress = identity.wallet.getWalletAddress(address);
@@ -35,7 +35,7 @@ define(['./module', 'darkwallet', 'bitcoinjs-lib'], function (controllers, DarkW
               }
 
               $scope.tools.exportAddresses = output;
-	      $scope.tools.exportComplete = true;
+              $scope.tools.exportComplete = true;
               $scope.tools.status = 'ok';
 
               notify.success(_('Exported'));

--- a/src/sass/_settings.scss
+++ b/src/sass/_settings.scss
@@ -533,7 +533,7 @@ $select-bg-color: $input-bg-color;
 // $off-canvas-label-text-transform: uppercase;
 // $off-canvas-label-font-weight: $font-weight-bold;
  $off-canvas-label-bg: #333;
-// $off-canvas-label-border-top: 1px solid scale-color(#444, $lightness: 14%);
+ $off-canvas-label-border-top: none;
 // $off-canvas-label-border-bottom: none;
 // $off-canvas-label-margin:0;
 // $off-canvas-link-padding: rem-calc(10, 15);

--- a/src/sass/_settings.scss
+++ b/src/sass/_settings.scss
@@ -423,7 +423,7 @@ $input-border-color: transparent;
 $input-focus-border-color: lighten($input-bg-color, 10%);// $input-border-style: solid;
 // $input-border-width: 1px;
 // $input-border-radius: $global-radius;
-$input-disabled-bg: #888;
+$input-disabled-bg: $body-bg;
 // $input-box-shadow: inset 0 1px 2px rgba(0,0,0,0.1);
 $input-include-glowing-effect: false;
 

--- a/test/unit/frontend/controllers/exportingSpec.js
+++ b/test/unit/frontend/controllers/exportingSpec.js
@@ -1,4 +1,125 @@
+/**
+ * @fileOverview ExportingCtrl angular controller
+ */
 'use strict';
 
-define(['frontend/controllers/exporting'], function (Exporting) {
+define(['angular-mocks', 'testUtils', 'bitcoinjs-lib'], function (mocks, testUtils, Bitcoin) {
+
+  describe('Exporting controller', function() {
+    var exportingController, scope, DarkWallet, notify;
+
+    var modals = {password: function(title, cb) {cb('pass');}};
+
+    var identity = {
+      wallet: {
+        getWalletAddress: function(address) {
+          return {address: address, type: 'hd'}
+        },
+        getPocketAddresses: function(pocketId) {
+          return ['1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH',
+                  '1cMh228HTCiwS8ZsaakH8A8wze1JR5ZsP',
+                  '1CUNEBjYrCn2y1SdiUMohaKUi4wpP326Lb']
+        },
+        getPrivateKey: function(address, pass, cb) {
+          var wif = '';
+          var addr = address.address;
+          // well-known keys with weak secret exponents (1,2,3)
+          if (addr == '1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH') {
+            wif = 'KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9M7rFU73sVHnoWn';
+          } else if (addr == '1cMh228HTCiwS8ZsaakH8A8wze1JR5ZsP') {
+            wif = 'KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9M7rFU74NMTptX4';
+          } else if (addr == '1CUNEBjYrCn2y1SdiUMohaKUi4wpP326Lb') {
+            wif = 'KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9M7rFU74sHUHy8S';
+          }
+          cb(Bitcoin.ECKey.fromWIF(wif))
+        }
+      }
+    };
+      
+    var injectController = function() {
+      mocks.inject(["$rootScope", "$controller", function ($rootScope, $controller) {
+        scope = $rootScope.$new();
+        notify = {};
+        notify.success = function() {};
+        notify.error = function() {};
+        var _ = function(s, x) {
+          return s.replace(/\{0\}/, x);
+        };
+        exportingController = $controller('ExportingCtrl', {$scope: scope, notify: notify, _Filter: _, modals: modals});
+      }]);
+    };
+    
+    beforeEach(function(done) {
+      window.chrome = {runtime: {}};
+      testUtils.stub('darkwallet', {
+        service: {
+          wallet: { 
+            mixTransaction: function() {}
+          }
+        },
+        getIdentity: function() {
+          return identity;
+        }
+      });
+
+      mocks.module("DarkWallet.controllers");
+      
+      testUtils.loadWithCurrentStubs('frontend/controllers/exporting', function() {
+        injectController();
+        DarkWallet = require('darkwallet');
+        done();
+      });
+    });
+    
+    afterEach(function() {
+      testUtils.reset();
+      delete window.chrome;
+    });
+
+    describe('', function() {
+
+      it('exports a key if an address is given', function() {
+        scope.tools = {};
+        scope.tools.exportAddresses = '1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH';
+        // spyOn(identity.wallet, 'getPrivateKey');
+        scope.exportKeys()
+        expect(scope.tools.exportAddresses).toBe(
+          '1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH' + ',' + 'KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9M7rFU73sVHnoWn' + '\n'
+        );
+      });
+
+      it('exports one key for every address given', function() {
+        scope.tools = {};
+        scope.tools.exportAddresses = '1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH' + '\n' +
+          '1cMh228HTCiwS8ZsaakH8A8wze1JR5ZsP';
+        scope.exportKeys()
+        expect(scope.tools.exportAddresses).toBe(
+          '1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH' + ',' + 'KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9M7rFU73sVHnoWn' + '\n' +
+          '1cMh228HTCiwS8ZsaakH8A8wze1JR5ZsP' + ',' + 'KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9M7rFU74NMTptX4' + '\n'
+        );
+      });
+
+       it('exports all keys if no input is given', function() {
+         scope.tools = {};
+         scope.tools.exportAddresses = '';
+         scope.exportKeys()
+         expect(scope.tools.exportAddresses).toBe(
+           '1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH' + ',' + 'KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9M7rFU73sVHnoWn' + '\n' +
+           '1cMh228HTCiwS8ZsaakH8A8wze1JR5ZsP' +  ',' + 'KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9M7rFU74NMTptX4' + '\n' +
+           '1CUNEBjYrCn2y1SdiUMohaKUi4wpP326Lb' + ',' + 'KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9M7rFU74sHUHy8S' + '\n'
+         );
+       });
+        
+       it('does not clear input on bad input', function() {
+         scope.tools = {};
+         scope.tools.exportAddresses = '123';
+         scope.exportKeys()
+         expect(scope.tools.exportAddresses).toBe('123');
+         expect(scope.tools.exportComplete).toBe(false);
+         // expect(scope.tools.exportOpen).toBe(true);
+         // expect(scope.tools.open).toBe(true);
+       });
+
+    });
+  });
 });


### PR DESCRIPTION
Temporary fix to get important functionality back, in ligh of issue 228 (all tools that used `$scope.tools` no longer work, since the window no longer has it).

Allows exporting multiple keys (again, based on hand-picked addresses).

UX is still rather poor, since there's no dialog to select wanted addresses, just a textarea, and no copy-to-clipboard button. After exporting, the tool stays open, to allow copying by hand (Select All, Copy).
